### PR TITLE
Fix PublishItemsOutputGroup computation

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets
@@ -1058,26 +1058,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
-                                        ComputeFilesCopiedToPublishDir
-
-    Gathers all the files that were copied to the publish directory.
-    ============================================================
-    -->
-  <Target Name="ComputeFilesCopiedToPublishDir"
-          DependsOnTargets="_CopyResolvedFilesToPublishPreserveNewest;
-                            _CopyResolvedFilesToPublishAlways;
-                            GenerateSingleFileBundle">
-
-    <ItemGroup>
-      <FilesCopiedToPublishDir Include="@(_ResolvedUnbundledFileToPublishPreserveNewest)"/>
-      <FilesCopiedToPublishDir Include="@(_ResolvedUnbundledFileToPublishAlways)"/>
-      <FilesCopiedToPublishDir Include="$(PublishedSingleFilePath)" RelativePath="$(PublishedSingleFileName)" IsKeyOutput="true" Condition="'$(PublishSingleFile)' == 'true'"/>
-    </ItemGroup>
-
-  </Target>
-
-  <!--
-    ============================================================
                                             PublishItemsOutputGroup
 
     Emit an output group containing all files that get published.  This will be consumed by VS installer projects.
@@ -1088,19 +1068,20 @@ Copyright (c) .NET Foundation. All rights reserved.
       $(PublishItemsOutputGroupDependsOn);
       ResolveReferences;
       ComputeFilesToPublish;
-      ComputeFilesCopiedToPublishDir;
     </PublishItemsOutputGroupDependsOn>
   </PropertyGroup>
 
   <Target Name="PublishItemsOutputGroup" DependsOnTargets="$(PublishItemsOutputGroupDependsOn)" Returns="@(PublishItemsOutputGroupOutputs)">
     <ItemGroup>
-      <PublishItemsOutputGroupOutputs Condition="'$(GenerateDependencyFile)' == 'true' and '$(_UseBuildDependencyFile)' != 'true' and '$(PublishSingleFile)' != 'true'"
-                                      Include="$(PublishDepsFilePath)"
-                                      TargetPath="$(ProjectDepsFileName)" />
-      <PublishItemsOutputGroupOutputs Include="@(FilesCopiedToPublishDir->'%(FullPath)')"
-                                      TargetPath="%(FilesCopiedToPublishDir.RelativePath)"
-                                      IsKeyOutput="%(FilesCopiedToPublishDir.IsKeyOutput)"
+      <PublishItemsOutputGroupOutputs Include="@(ResolvedFileToPublish->'%(FullPath)')"
+                                      TargetPath="%(ResolvedFileToPublish.RelativePath)"
+                                      IsKeyOutput="%(ResolvedFileToPublish.IsKeyOutput)"
                                       OutputGroup="PublishItemsOutputGroup" />
+      <PublishItemsOutputGroupOutputs Include="$(PublishedSingleFilePath)"
+                                      TargetPath="$(PublishedSingleFileName)"
+                                      IsKeyOutput="true"
+                                      OutputGroup="PublishItemsOutputGroup" 
+                                      Condition="'$(PublishSingleFile)' == 'true'" />    
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This change fixes a failure in merging release/5.0.1xx-preview1 to master

Given 1f2a4a1, we should undo most of the change in 43eb71d, because `ResolvedFilesToPublish` is actually consistent now in both single-file and non-single-file scenarios.
In `PublishSingleFile` case, we only need to add the single-file bundle itself.
No special handling is necessary for the deps.json file, since it is now included within `ResolvedFilesToPublish` list.